### PR TITLE
fix uri_for() if app is mounted on non '/' location.

### DIFF
--- a/lib/Kossy.pm
+++ b/lib/Kossy.pm
@@ -429,7 +429,10 @@ sub param_raw {
 sub uri_for {
      my($self, $path, $args) = @_;
      my $uri = $self->base;
-     $uri->path($path);
+     my $base = $uri->path eq "/"
+              ? ""
+              : $uri->path;
+     $uri->path( $base . $path );
      $uri->query_form(@$args) if $args;
      $uri;
 }

--- a/t/03_mount.t
+++ b/t/03_mount.t
@@ -1,0 +1,54 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Basename;
+use Plack::Builder;
+use Plack::Test;
+use HTTP::Request::Common;
+use lib "t";
+
+use_ok "MyApp";
+
+my $root_dir = File::Basename::dirname(__FILE__);
+my $app = MyApp->psgi($root_dir);
+
+subtest "/" => sub {
+    test_psgi
+        app    => $app,
+        client => sub {
+            my $cb  = shift;
+            my $res = $cb->( GET "http://localhost/" );
+            is $res->code, 200;
+            is $res->content, "ok";
+
+            $res = $cb->( GET "http://localhost/foo" );
+            is $res->code, 404;
+
+            $res = $cb->( GET "http://localhost/uri_for" );
+            is $res->code, 200;
+            is $res->content, "http://localhost/uri_for";
+        };
+};
+
+subtest "/mount" => sub {
+    test_psgi
+        app    => builder { mount "/mount", $app },
+        client => sub {
+            my $cb  = shift;
+            my $res = $cb->( GET "http://localhost/" );
+            is $res->code, 404;
+
+            $res = $cb->( GET "http://localhost/mount/" );
+            is $res->code, 200;
+            is $res->content, "ok";
+
+            $res = $cb->( GET "http://localhost/mount/foo" );
+            is $res->code, 404;
+
+            $res = $cb->( GET "http://localhost/mount/uri_for" );
+            is $res->code, 200;
+            is $res->content, "http://localhost/mount/uri_for";
+        };
+};
+
+done_testing;

--- a/t/MyApp.pm
+++ b/t/MyApp.pm
@@ -4,6 +4,15 @@ use strict;
 use warnings;
 use Kossy;
 
+get "/" => sub {
+    my ( $self, $c )  = @_;
+    $c->response->body("ok");
+};
+
+get "/uri_for" => sub {
+    my ( $self, $c )  = @_;
+    $c->response->body( $c->request->uri_for("/uri_for")->as_string );
+};
 
 1;
 


### PR DESCRIPTION
Hi.
If the app is mounted on non "/" location, uri_for() returns path which not included mounted location.
I fixed uri_for().
