### PR TITLE
s/Router::Simple/Router::Boom/

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Kossy - Sinatra-ish Simple and Clear web application framework
 
 # DESCRIPTION
 
-Kossy is Sinatra-ish Simple and Clear web application framework, which is based upon [Plack](https://metacpan.org/pod/Plack), [Router::Simple](https://metacpan.org/pod/Router::Simple), [Text::Xslate](https://metacpan.org/pod/Text::Xslate) and build-in Form-Validator. That's suitable for small application and rapid development.
+Kossy is Sinatra-ish Simple and Clear web application framework, which is based upon [Plack](https://metacpan.org/pod/Plack), [Router::Boom](https://metacpan.org/pod/Router::Boom), [Text::Xslate](https://metacpan.org/pod/Text::Xslate) and build-in Form-Validator. That's suitable for small application and rapid development.
 
 # Kossy class
 

--- a/lib/Kossy.pm
+++ b/lib/Kossy.pm
@@ -273,7 +273,7 @@ Kossy - Sinatra-ish Simple and Clear web application framework
 
 =head1 DESCRIPTION
 
-Kossy is Sinatra-ish Simple and Clear web application framework, which is based upon L<Plack>, L<Router::Simple>, L<Text::Xslate> and build-in Form-Validator. That's suitable for small application and rapid development.
+Kossy is Sinatra-ish Simple and Clear web application framework, which is based upon L<Plack>, L<Router::Boom>, L<Text::Xslate> and build-in Form-Validator. That's suitable for small application and rapid development.
 
 =head1 Kossy class
 


### PR DESCRIPTION
もう使われていないRouter::Simpleがドキュメントに残ってたのでRouter::Boomに置き換えました。
