### PR TITLE
remove BOM from JSON

### DIFF
--- a/lib/Kossy/Connection.pm
+++ b/lib/Kossy/Connection.pm
@@ -75,7 +75,7 @@ sub render_json {
 
     # defense from JSON hijacking
     # Copy from Amon2::Plugin::Web::JSON
-    if ( exists $self->req->env->{'HTTP_X_REQUESTED_WITH'} && 
+    if ( exists $self->req->env->{'HTTP_X_REQUESTED_WITH'} &&
          ($self->req->env->{'HTTP_USER_AGENT'}||'') =~ /android/i &&
          exists $self->req->env->{'HTTP_COOKIE'} &&
          ($self->req->method||'GET') eq 'GET'
@@ -86,15 +86,11 @@ sub render_json {
     my $body = $_JSON->encode($obj);
     $body = $self->escape_json($body);
 
-    if ( ( $self->req->env->{'HTTP_USER_AGENT'} || '' ) =~ m/Safari/ ) {
-        $body = "\xEF\xBB\xBF" . $body;
-    }
-
     $self->res->status( 200 );
     $self->res->content_type('application/json; charset=UTF-8');
     $self->res->header( 'X-Content-Type-Options' => 'nosniff' ); # defense from XSS
     $self->res->body( $body );
-    $self->res;    
+    $self->res;
 }
 
 


### PR DESCRIPTION
This pull request removes BOM from JSON.

- Reasons:
  - Could not parse in Safari (version 14.1.2 (15611.3.10.1.5, 15611))
  - The following is an RFC:

    https://datatracker.ietf.org/doc/html/rfc8259#section-8.1 (December 2017)
    > Implementations MUST NOT add a byte order mark (U+FEFF) to the
       beginning of a networked-transmitted JSON text.

    https://datatracker.ietf.org/doc/html/rfc7158#section-8.1 (March 2013)
    > Implementations MUST NOT add a byte order mark to the beginning of a
       JSON text.