### PR TITLE
add halt_text/halt_no_content

### DIFF
--- a/lib/Kossy/Connection.pm
+++ b/lib/Kossy/Connection.pm
@@ -46,6 +46,20 @@ sub halt {
     die Kossy::Exception->new(@_);
 }
 
+sub halt_text {
+    my ($self, $code, $message) = @_;
+    $self->res->content_type('text/plain');
+    $self->res->body($message);
+    die Kossy::Exception->new($code, response => $self->res);
+}
+
+sub halt_no_content {
+    my ($self, $code) = @_;
+    $self->res->headers->remove_content_headers;
+    $self->res->content_length(0);
+    die Kossy::Exception->new($code, response => $self->res);
+}
+
 sub redirect {
     my $self = shift;
     $self->res->redirect(@_);

--- a/lib/Kossy/Exception.pm
+++ b/lib/Kossy/Exception.pm
@@ -29,18 +29,25 @@ sub new {
 sub response {
     my $self = shift;
     my $code = $self->{code} || 500;
-    my $message = $self->{message};
-    $message ||= HTTP::Status::status_message($code);
 
-    my @headers = (
-         'Content-Type' => q!text/html; charset=UTF-8!,
-    );
-
-    if ($code =~ /^3/ && (my $loc = eval { $self->{location} })) {
-        push(@headers, Location => $loc);
+    if ($self->{response}) {
+        $self->{response}->code($code);
+        return $self->{response}->finalize;
     }
+    else {
+        my $message = $self->{message};
+        $message ||= HTTP::Status::status_message($code);
 
-    return Kossy::Response->new($code, \@headers, [$self->html($code,$message)])->finalize;
+        my @headers = (
+             'Content-Type' => q!text/html; charset=UTF-8!,
+        );
+
+        if ($code =~ /^3/ && (my $loc = eval { $self->{location} })) {
+            push(@headers, Location => $loc);
+        }
+
+        return Kossy::Response->new($code, \@headers, [$self->html($code,$message)])->finalize;
+    }
 }
 
 sub html {

--- a/t/kossy-connection/halt.t
+++ b/t/kossy-connection/halt.t
@@ -1,0 +1,124 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Kossy::Connection;
+use Plack::Response;
+
+my $c = Kossy::Connection->new();
+
+local $Kossy::Response::SECURITY_HEADER = 0;
+
+subtest "default case" => sub {
+    eval { $c->halt() };
+
+    isa_ok $@, 'Kossy::Exception';
+    my ($code, $headers, $body) = @{ $@->response };
+
+    is $code, 500;
+    like $body->[0], qr/Internal Server Error/;
+    is_deeply $headers, [
+        'Content-Type' => 'text/html; charset=UTF-8',
+    ];
+};
+
+subtest "only code" => sub {
+    eval { $c->halt(404) };
+
+    isa_ok $@, 'Kossy::Exception';
+    my ($code, $headers, $body) = @{ $@->response };
+
+    is $code, 404;
+    like $body->[0], qr/Not Found/;
+    is_deeply $headers, [
+        'Content-Type' => 'text/html; charset=UTF-8',
+    ];
+};
+
+subtest "code and message" => sub {
+    eval { $c->halt(201, "Created Foo") };
+
+    isa_ok $@, 'Kossy::Exception';
+    my ($code, $headers, $body) = @{ $@->response };
+
+    is $code, 201;
+    like $body->[0], qr/Created Foo/;
+    is_deeply $headers, [
+        'Content-Type' => 'text/html; charset=UTF-8',
+    ];
+};
+
+subtest "code and message / named interface" => sub {
+    eval { $c->halt(500, message => "My Error") };
+
+    isa_ok $@, 'Kossy::Exception';
+    my ($code, $headers, $body) = @{ $@->response };
+
+    is $code, 500;
+    like $body->[0], qr/My Error/;
+    is_deeply $headers, [
+        'Content-Type' => 'text/html; charset=UTF-8',
+    ];
+};
+
+subtest "location" => sub {
+    eval { $c->halt(301, location => "/foo") };
+
+    isa_ok $@, 'Kossy::Exception';
+    my ($code, $headers, $body) = @{ $@->response };
+
+    is $code, 301;
+    like $body->[0], qr/Moved Permanently/;
+    is_deeply $headers, [
+        'Location'     => '/foo',
+        'Content-Type' => 'text/html; charset=UTF-8',
+    ];
+};
+
+subtest "no location" => sub {
+    eval { $c->halt(301) };
+
+    isa_ok $@, 'Kossy::Exception';
+    my ($code, $headers, $body) = @{ $@->response };
+
+    is $code, 301;
+    like $body->[0], qr/Moved Permanently/;
+    is_deeply $headers, [
+        'Content-Type' => 'text/html; charset=UTF-8',
+    ];
+};
+
+
+subtest "original response" => sub {
+    my $res = Plack::Response->new();
+    $res->content_type('application/json');
+    $res->body("{ 'error': 'Bad Request!!' }");
+    $res->code(200);
+
+    eval { $c->halt(400, response => $res) };
+
+    isa_ok $@, 'Kossy::Exception';
+    my ($code, $headers, $body) = @{ $@->response };
+
+    is $code, 400; # override 200
+    is $body->[0], "{ 'error': 'Bad Request!!' }";
+    is_deeply $headers, [
+        'Content-Type' => 'application/json',
+    ];
+};
+
+subtest "odd arguments" => sub {
+    eval { $c->halt(201, message => 'Foo!!', 'bar') };
+
+    isa_ok $@, 'Kossy::Exception';
+    my ($code, $headers, $body) = @{ $@->response };
+
+    is $code, 201;
+    like $body->[0], qr/Created/;
+    unlike $body->[0], qr/Foo!!/;
+    is_deeply $headers, [
+        'Content-Type' => 'text/html; charset=UTF-8',
+    ];
+};
+
+done_testing;

--- a/t/kossy-connection/halt_no_content.t
+++ b/t/kossy-connection/halt_no_content.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Kossy::Connection;
+use Plack::Response;
+
+my $c = Kossy::Connection->new(
+    res => Plack::Response->new,
+);
+
+subtest "normal case" => sub {
+    eval { $c->halt_no_content(201) };
+
+    isa_ok $@, 'Kossy::Exception';
+    is_deeply $@->response, [
+        201,
+        [ 'Content-Length' => 0 ],
+        [ ],
+    ];
+};
+
+subtest "no code" => sub {
+    eval { $c->halt_no_content() };
+
+    isa_ok $@, 'Kossy::Exception';
+    is_deeply $@->response, [
+        500,
+        [ 'Content-Length' => 0 ],
+        [ ],
+    ];
+};
+
+done_testing;

--- a/t/kossy-connection/halt_text.t
+++ b/t/kossy-connection/halt_text.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Kossy::Connection;
+use Plack::Response;
+
+my $c = Kossy::Connection->new(
+    res => Plack::Response->new,
+);
+
+subtest "normal case" => sub {
+    eval { $c->halt_text(201, 'hello') };
+
+    isa_ok $@, 'Kossy::Exception';
+    is_deeply $@->response, [
+        201,
+        [ 'Content-Type' => 'text/plain' ],
+        [ 'hello' ],
+    ];
+};
+
+subtest "no code" => sub {
+    eval { $c->halt_text() };
+
+    isa_ok $@, 'Kossy::Exception';
+    is_deeply $@->response, [
+        500,
+        [ 'Content-Type' => 'text/plain' ],
+        [  ],
+    ];
+};
+
+subtest "no message" => sub {
+    eval { $c->halt_text(200) };
+
+    isa_ok $@, 'Kossy::Exception';
+    is_deeply $@->response, [
+        200,
+        [ 'Content-Type' => 'text/plain' ],
+        [  ],
+    ];
+};
+
+done_testing;


### PR DESCRIPTION
This pull request add halt_text and halt_no_content method in Kossy::Connection.

- halt_text's Content-Type is text/plain,
- halt_no_content has Content-Length 0

These two halts are useful when it is sufficient to receive a simple response, such as in a Single Page Application.