### PR TITLE
Customize json serializer

### DIFF
--- a/lib/Kossy.pm
+++ b/lib/Kossy.pm
@@ -585,12 +585,14 @@ changes the JSON serializer:
     use Cpanel::JSON::XS;
     use Cpanel::JSON::XS::Type;
 
-    $Kossy::JSON_SERIALIZER = Cpanel::JSON::XS->new()->allow_blessed(1)->convert_blessed(1)->ascii(0);
+    local $Kossy::JSON_SERIALIZER = Cpanel::JSON::XS->new()->allow_blessed(1)->convert_blessed(1)->ascii(0);
 
     get '/' => sub {
         my ($self, $c) = @_;
         return $c->render_json({ a => '234' }, { a => JSON_TYPE_INT });
     };
+
+    my $app = __PACKAGE__->psgi;
 
 =back
 

--- a/lib/Kossy.pm
+++ b/lib/Kossy.pm
@@ -9,6 +9,8 @@ use Cwd qw//;
 use File::Basename qw//;
 use Text::Xslate;
 use HTML::FillInForm::Lite qw//;
+use JSON qw//;
+use Scalar::Util qw//;
 use Try::Tiny;
 use Encode;
 use Router::Boom;
@@ -29,6 +31,7 @@ our @EXPORT = qw/new root_dir psgi build_app _router _connect get post router fi
 our $XSLATE_CACHE = 1;
 our $XSLATE_CACHE_DIR;
 our $SECURITY_HEADER = 1;
+our $JSON_SERIALIZER;
 
 # cache underscore translation
 HTTP::Headers::Fast::_standardize_field_name('X-Frame-Options');
@@ -74,29 +77,16 @@ sub build_app {
     #router
     my $router = Router::Boom->new;
     $router->add($_ => $self->_router->{$_} ) for keys %{$self->_router};
-    my $xslate_cache_local = $XSLATE_CACHE;
-    my $xslate_cache_dir_local = $XSLATE_CACHE_DIR;
     my $security_header_local = $SECURITY_HEADER;
     my %match_cache;
 
-    #xslate
-    my $fif = HTML::FillInForm::Lite->new();
-    my $tx = Text::Xslate->new(
-        path => [ $self->root_dir . '/views' ],
-        input_layer => ':utf8',
-        module => ['Text::Xslate::Bridge::TT2Like','Number::Format' => [':subs']],
-        function => {
-            fillinform => sub {
-                my $q = shift;
-                return sub {
-                    my ($html) = @_;
-                    return Text::Xslate::mark_raw( $fif->fill( \$html, $q ) );
-                }
-            }
-        },
-        cache => $xslate_cache_local,
-        defined $xslate_cache_dir_local ? ( cache_dir => $xslate_cache_dir_local ) : (),
+    my $tx = __PACKAGE__->_build_text_xslate(
+        root_dir  => $self->root_dir,
+        cache     => $XSLATE_CACHE,
+        cache_dir => $XSLATE_CACHE_DIR,
     );
+
+    my $json_serializer = __PACKAGE__->_build_json_serializer();
 
     sub {
         my $env = shift;
@@ -111,6 +101,7 @@ sub build_app {
                 req => Kossy::Request->new($env),
                 res => Kossy::Response->new(200, $header),
                 stash => {},
+                json_serializer => $json_serializer,
             });
             my $method = uc($env->{REQUEST_METHOD});
             my $cache_key = $method . '-' . $env->{PATH_INFO};
@@ -186,15 +177,54 @@ sub build_app {
     };
 }
 
+sub _build_text_xslate {
+    my ($class, %args) = @_;
+    my ($root_dir, $cache, $cache_dir) = @args{qw/root_dir cache cache_dir/};
+
+    my $fif = HTML::FillInForm::Lite->new();
+    my $tx = Text::Xslate->new(
+        path => [ $root_dir . '/views' ],
+        input_layer => ':utf8',
+        module => ['Text::Xslate::Bridge::TT2Like','Number::Format' => [':subs']],
+        function => {
+            fillinform => sub {
+                my $q = shift;
+                return sub {
+                    my ($html) = @_;
+                    return Text::Xslate::mark_raw( $fif->fill( \$html, $q ) );
+                }
+            }
+        },
+        cache => $cache,
+        defined $cache_dir ? ( cache_dir => $cache_dir ) : (),
+    );
+    return $tx
+}
+
+sub _build_json_serializer {
+    my $class = shift;
+
+    if (defined $JSON_SERIALIZER) {
+        if (Scalar::Util::blessed($JSON_SERIALIZER) && $JSON_SERIALIZER->can('encode')) {
+            return $JSON_SERIALIZER
+        }
+        else {
+            Carp::croak '$Kossy::JSON_SERIALIZER must have `encode` method';
+        }
+    }
+
+    # default case
+    return JSON->new()->allow_blessed(1)->convert_blessed(1)->ascii(1);
+}
 
 
 my $_ROUTER={};
 sub _router {
     my $klass = shift;
-    my $class = ref $klass ? ref $klass : $klass; 
+    my $class = ref $klass ? ref $klass : $klass;
     if ( !$_ROUTER->{$class} ) {
         $_ROUTER->{$class} = {};
-    }    
+    }
     $_ROUTER->{$class};
 }
 
@@ -544,9 +574,23 @@ If disabled, Kossy does not set X-Frame-Options and X-XSS-Protection. enabled by
   local $Kossy::SECURITY_HEADER = 0;
   my $app = MyApp::Web->psgi;
 
-Can not change $Kossy::SECURITY_HEADER in your WebApp. It's need to set at build time. 
+Can not change $Kossy::SECURITY_HEADER in your WebApp. It's need to set at build time.
 
 This is useful for the benchmark :-)
+
+=item $JSON_SERIALIZER
+
+changes the JSON serializer:
+
+    use Cpanel::JSON::XS;
+    use Cpanel::JSON::XS::Type;
+
+    $Kossy::JSON_SERIALIZER = Cpanel::JSON::XS->new()->allow_blessed(1)->convert_blessed(1)->ascii(0);
+
+    get '/' => sub {
+        my ($self, $c) = @_;
+        return $c->render_json({ a => '234' }, { a => JSON_TYPE_INT });
+    };
 
 =back
 

--- a/t/kossy-connection/render.t
+++ b/t/kossy-connection/render.t
@@ -1,0 +1,49 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Kossy::Connection;
+use Plack::Request;
+use Plack::Response;
+
+my $env = {};
+my $c = Kossy::Connection->new(
+    tx  => MyTemplate->new,
+    req => Plack::Request->new($env),
+    res => Plack::Response->new,
+);
+
+subtest 'normal case' => sub {
+    my $res = $c->render('myfile', { a => 'hello' });
+
+    is $res->code, 200;
+    is_deeply $res->body, {
+        file => 'myfile',
+        vars => {
+            a     => 'hello',
+            c     => $c,
+            stash => undef,
+        }
+    };
+    is $res->header('Content-Type'), 'text/html; charset=UTF-8';
+};
+
+done_testing;
+
+package MyTemplate;
+
+sub new {
+    my $class = shift;
+    return bless {}, $class;
+}
+
+sub render {
+    my $self = shift;
+    my ($file, $vars) = @_;
+
+    return {
+        file => $file,
+        vars => $vars,
+    }
+}
+

--- a/t/kossy-connection/render_json.t
+++ b/t/kossy-connection/render_json.t
@@ -5,11 +5,14 @@ use Test::More;
 use Kossy::Connection;
 use Plack::Request;
 use Plack::Response;
+use JSON qw//;
 
 my $env = {};
+my $json_serializer = JSON->new();
 my $c = Kossy::Connection->new(
     req => Plack::Request->new($env),
     res => Plack::Response->new,
+    json_serializer => $json_serializer,
 );
 
 subtest 'default case' => sub {
@@ -41,4 +44,24 @@ subtest 'json hijack' => sub {
     };
 };
 
+subtest 'customize json_serializer' => sub {
+    my $json_serializer = MyJSONSerializer->new;
+    $c->json_serializer($json_serializer);
+
+    my $res = $c->render_json("foo", "bar", "baz");
+    is $res->body, 'foo-bar-baz';
+};
+
 done_testing;
+
+package MyJSONSerializer;
+
+sub new {
+    my $class = shift;
+    return bless {}, $class;
+}
+
+sub encode {
+    my $self = shift;
+    join '-', @_;
+}

--- a/t/kossy/build_json_serializer.t
+++ b/t/kossy/build_json_serializer.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Kossy;
+
+subtest 'normal' => sub {
+    my $json = Kossy->_build_json_serializer;
+
+    isa_ok $json, 'JSON';
+    ok $json->allow_blessed;
+    ok $json->convert_blessed;
+    ok $json->ascii;
+};
+
+subtest 'customize json_serializer' => sub {
+    my $json_serializer = JSON->new;
+    local $Kossy::JSON_SERIALIZER = $json_serializer;
+    my $json = Kossy->_build_json_serializer;
+    is $json, $json_serializer;
+};
+
+subtest 'exceptions' => sub {
+    subtest 'not blessed' => sub {
+        my $json_serializer = 'Hoge';
+        local $Kossy::JSON_SERIALIZER = $json_serializer;
+        eval { Kossy->_build_json_serializer };
+        like $@, qr/\$Kossy::JSON_SERIALIZER must have/;
+    };
+
+    subtest 'blessed & no encode method' => sub {
+        my $json_serializer = bless {}, 'Hoge';
+        local $Kossy::JSON_SERIALIZER = $json_serializer;
+        eval { Kossy->_build_json_serializer };
+        like $@, qr/\$Kossy::JSON_SERIALIZER must have/;
+    };
+};
+
+done_testing;

--- a/t/kossy/build_text_xslate.t
+++ b/t/kossy/build_text_xslate.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Kossy;
+
+subtest 'with cache' => sub {
+    my $tx = Kossy->_build_text_xslate(
+        root_dir  => '/path/to/root',
+        cache     => 1,
+        cache_dir => '/path/to/cache_dir',
+    );
+
+    isa_ok $tx, 'Text::Xslate';
+    is_deeply $tx->{path}, ['/path/to/root/views'];
+    is $tx->input_layer, ':utf8';
+    is $tx->{cache}, 1;
+    is $tx->{cache_dir}, '/path/to/cache_dir';
+
+    local $TODO = 'test fillinform';
+    ok $tx->{function}->{fillinform};
+};
+
+subtest 'no cache' => sub {
+    my $tx = Kossy->_build_text_xslate(
+        root_dir => '/path/to/root',
+        cache    => 0,
+    );
+
+    isa_ok $tx, 'Text::Xslate';
+    is_deeply $tx->{path}, ['/path/to/root/views'];
+    is $tx->{cache}, 0;
+    like $tx->{cache_dir}, qr/\.xslate_cache/;
+};
+
+done_testing;

--- a/t/kossy/json_serializer.t
+++ b/t/kossy/json_serializer.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
+
+use Kossy;
+
+local $Kossy::JSON_SERIALIZER = MyJSONSerializer->new;
+
+get '/' => sub {
+    my ($self, $c) = @_;
+    isa_ok($c->json_serializer, 'MyJSONSerializer');
+    return $c->render_json({ a => 1 });
+};
+
+my $app = __PACKAGE__->psgi;
+
+test_psgi($app, sub {
+    my $cb  = shift;
+    my $res = $cb->(GET "/");
+    is $res->content, "a:1";
+});
+
+done_testing;
+
+package MyJSONSerializer;
+
+sub new {
+    my $class = shift;
+    return bless {}, $class;
+}
+
+sub encode {
+    my ($self, $obj) = @_;
+    join '-', map { "$_:$obj->{$_}" } sort keys %$obj;
+}
+


### PR DESCRIPTION
This pull request will allow customization of the JSON serializer.
For example, Cpanel::JSON::XS::Type can be used in the following way:

```perl
use Cpanel::JSON::XS;
use Cpanel::JSON::XS::Type;
 
local $Kossy::JSON_SERIALIZER = Cpanel::JSON::XS->new()->allow_blessed(1)->convert_blessed(1)->ascii(0);
 
get '/' => sub {
    my ($self, $c) = @_;
    return $c->render_json({ a => '234' }, { a => JSON_TYPE_INT });
};
my $app = __PACKAGE__->psgi;
```

!!Caution
This pull request merged #16.
