### PR TITLE
Fixed JSON request had 1 or 0 array elements and add json_parameters method

### DIFF
--- a/lib/Kossy.pm
+++ b/lib/Kossy.pm
@@ -513,6 +513,35 @@ validate parameters using L<Kossy::Validator>
 
 These methods are the accessor to raw values. 'raw' means the value is not decoded.
 
+=item body_parameters
+
+Accessor to decoded body parameters. It's Hash::MultiValue object.
+
+=item query_parameters
+
+Accessor to decoded query parameters. It's Hash::MultiValue object.
+
+=item json_parameters
+
+Accessor to decoded JSON body parameters. It's B<NOT> Hash::MultiValue object.
+
+    post '/api' => sub {
+        my ($self, $c) = @_;
+        my $foo = $c->req->json_parameters->{foo}; # bar
+    };
+
+    # requrest
+    # $ua->requrest(
+    #     HTTP::Request->new(
+    #         "POST",
+    #         "http://example.com/api",
+    #         [ "Content-Type" => 'application/json', "Content-Length" => 13 ],
+    #         '{"foo":"bar"}'
+    #     )
+    # );
+
+NOTE: Not need to set C<kossy.request.parse_json_body> to 1
+
 =back
 
 =head1 Kossy::Response

--- a/lib/Kossy/Request.pm
+++ b/lib/Kossy/Request.pm
@@ -130,7 +130,7 @@ sub body_parameters {
 sub json_parameters {
     my ($self) = @_;
     $self->env->{'kossy.request.json_body'} ||= do {
-        Hash::MultiValue->new(map { _decode_recursively($_) } @{$self->_json_parameters()});
+        +{ map { _decode_recursively($_) } @{$self->_json_parameters()} }
     }
 }
 

--- a/t/002_kossy-request/parameters_decoded.t
+++ b/t/002_kossy-request/parameters_decoded.t
@@ -64,7 +64,7 @@ subtest 'Decode body parameters' => sub {
     subtest 'with default parser' => sub {
         test_psgi $app, sub {
             my $cb = shift;
-            $cb->(POST '/', { 
+            $cb->(POST '/', {
                 p1 => '👍',
                 p2 => ['☀️', '🌕'],
             });
@@ -74,7 +74,7 @@ subtest 'Decode body parameters' => sub {
     subtest 'with json parser' => sub {
         test_psgi filter_json($app), sub {
             my $cb = shift;
-            $cb->(POST '/', { 
+            $cb->(POST '/', {
                 p1 => '👍',
                 p2 => ['☀️', '🌕'],
             });
@@ -88,16 +88,29 @@ subtest 'Decode JSON body parameters' => sub {
         my $env = shift;
         my $req = Kossy::Request->new($env);
 
-        my $p1 = $req->body_parameters->{'p1'};
+        subtest 'body_parameters' => sub {
+            my $p1 = $req->body_parameters->{'p1'};
 
-        # NOTE: There is no need to use `get_all` method to get all of the array values.
-        my $p2 = $req->body_parameters->{'p2'};
+            # NOTE: There is no need to use `get_all` method to get all of the array values.
+            my $p2 = $req->body_parameters->{'p2'};
 
-        ok Encode::is_utf8($p1);
-        ok Encode::is_utf8($_) for @$p2;
+            ok Encode::is_utf8($p1);
+            ok Encode::is_utf8($_) for @$p2;
 
-        is $p1, '👍', 'The thumb up emoji is correctly decoded';
-        is_deeply $p2, ['☀️', '🌕'], 'The sun and full moon emoji are correctly decoded';
+            is $p1, '👍', 'The thumb up emoji is correctly decoded';
+            is_deeply $p2, ['☀️', '🌕'], 'The sun and full moon emoji are correctly decoded';
+        };
+
+        subtest 'json_parameters' => sub {
+            my $p1 = $req->json_parameters->{'p1'};
+            my $p2 = $req->json_parameters->{'p2'};
+
+            ok Encode::is_utf8($p1);
+            ok Encode::is_utf8($_) for @$p2;
+
+            is $p1, '👍', 'The thumb up emoji is correctly decoded';
+            is_deeply $p2, ['☀️', '🌕'], 'The sun and full moon emoji are correctly decoded';
+        };
 
         $req->new_response(200)->finalize;
     };

--- a/t/002_kossy-request/parameters_decoded.t
+++ b/t/002_kossy-request/parameters_decoded.t
@@ -9,67 +9,112 @@ use HTTP::Request::Common;
 use JSON qw(encode_json);
 use Encode ();
 
-my $app = sub {
-    my $env = shift;
-    my $req = Kossy::Request->new($env);
+# create a test app that parses JSON body
+sub filter_json {
+    my $app = shift;
 
-    ok Encode::is_utf8($req->query_parameters->{'q'});
-    is $req->query_parameters->{'q'}, '👍', 'The thumb up emoji is correctly decoded';
+    sub {
+        my $env = shift;
+        $env->{'kossy.request.parse_json_body'} = 1;
+        $app->($env);
+    }
+}
 
-    ok Encode::is_utf8($req->body_parameters->{'b'});
-    is $req->body_parameters->{'b'}, 'こんにちは', 'Japanese greeting is correctly decoded';
+subtest 'Decode query parameters' => sub {
+    my $app = sub {
+        my $env = shift;
+        my $req = Kossy::Request->new($env);
 
-    my @q2 = $req->query_parameters->get_all('q2');
-    ok Encode::is_utf8($_) for @q2;
-    is_deeply \@q2, ['☀️', '🌕'], 'The sun and full moon emoji are correctly decoded';
+        my $p1 = $req->query_parameters->{'p1'};
+        my @p2 = $req->query_parameters->get_all('p2');
 
-    my @b2 = $req->body_parameters->get_all('b2');
-    ok Encode::is_utf8($_) for @b2;
-    is_deeply \@b2, ['おはよう', 'こんばんは'], 'Japanese greeting are correctly decoded';
+        ok Encode::is_utf8($p1);
+        ok Encode::is_utf8($_) for @p2;
 
-    $req->new_response(200)->finalize;
-};
+        is $p1, '👍', 'The thumb up emoji is correctly decoded';
+        is_deeply \@p2, ['☀️', '🌕'], 'The sun and full moon emoji are correctly decoded';
 
-my $parse_json_app = sub {
-    my $env = shift;
-    $env->{'kossy.request.parse_json_body'} = 1;
-    $app->($env);
-};
-
-my $query = 'q=%F0%9F%91%8D&q2=%E2%98%80%EF%B8%8F&q2=%F0%9F%8C%95';
-my $body_parameters = {
-    b  => 'こんにちは',
-    b2 => ['おはよう', 'こんばんは'],
-};
-
-subtest 'default parser' => sub {
-    my $request = POST "/?$query", $body_parameters;
+        $req->new_response(200)->finalize;
+    };
 
     test_psgi $app, sub {
         my $cb = shift;
-        $cb->($request);
+        $cb->(GET "/?p1=%F0%9F%91%8D&p2=%E2%98%80%EF%B8%8F&p2=%F0%9F%8C%95");
     };
 };
 
-subtest 'json parser' => sub {
-    my $request = POST "/?$query", $body_parameters;
+subtest 'Decode body parameters' => sub {
 
-    test_psgi $parse_json_app, sub {
-        my $cb = shift;
-        $cb->($request);
+    my $app = sub {
+        my $env = shift;
+        my $req = Kossy::Request->new($env);
+
+        my $p1 = $req->body_parameters->{'p1'};
+        my @p2 = $req->body_parameters->get_all('p2');
+
+        ok Encode::is_utf8($p1);
+        ok Encode::is_utf8($_) for @p2;
+
+        is $p1, '👍', 'The thumb up emoji is correctly decoded';
+        is_deeply \@p2, ['☀️', '🌕'], 'The sun and full moon emoji are correctly decoded';
+
+        $req->new_response(200)->finalize;
+    };
+
+    subtest 'with default parser' => sub {
+        test_psgi $app, sub {
+            my $cb = shift;
+            $cb->(POST '/', { 
+                p1 => '👍',
+                p2 => ['☀️', '🌕'],
+            });
+        };
+    };
+
+    subtest 'with json parser' => sub {
+        test_psgi filter_json($app), sub {
+            my $cb = shift;
+            $cb->(POST '/', { 
+                p1 => '👍',
+                p2 => ['☀️', '🌕'],
+            });
+        };
     };
 };
 
-subtest 'JSON request with json parser' => sub {
-    my $request = POST "/?$query";
+subtest 'Decode JSON body parameters' => sub {
 
-    my $encocded_json = encode_json($body_parameters);
-    $request->header('Content-Type' => 'application/json; charset=utf-8');
-    $request->header('Content-Length' => length $encocded_json);
-    $request->content($encocded_json);
+    my $app = sub {
+        my $env = shift;
+        my $req = Kossy::Request->new($env);
 
-    test_psgi $parse_json_app, sub {
+        my $p1 = $req->body_parameters->{'p1'};
+
+        # NOTE: There is no need to use `get_all` method to get all of the array values.
+        my $p2 = $req->body_parameters->{'p2'};
+
+        ok Encode::is_utf8($p1);
+        ok Encode::is_utf8($_) for @$p2;
+
+        is $p1, '👍', 'The thumb up emoji is correctly decoded';
+        is_deeply $p2, ['☀️', '🌕'], 'The sun and full moon emoji are correctly decoded';
+
+        $req->new_response(200)->finalize;
+    };
+
+    test_psgi filter_json($app), sub {
         my $cb = shift;
+
+        my $request = POST "/";
+
+        my $encocded_json = encode_json({
+            p1 => '👍',
+            p2 => ['☀️', '🌕'],
+        });
+        $request->header('Content-Type' => 'application/json; charset=utf-8');
+        $request->header('Content-Length' => length $encocded_json);
+        $request->content($encocded_json);
+
         $cb->($request);
     };
 };

--- a/t/100_bugs/002_a_few_parameters_in_json_body.t
+++ b/t/100_bugs/002_a_few_parameters_in_json_body.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Kossy;
+use Plack::Test;
+use HTTP::Request::Common;
+use JSON qw(encode_json);
+
+sub run_test {
+    my $data = shift;
+
+    my $app = sub {
+        my $env = shift;
+        $env->{'kossy.request.parse_json_body'} = 1; # parse json body
+
+        my $req = Kossy::Request->new($env);
+
+        is_deeply $req->body_parameters->as_hashref_mixed, $data;
+
+        $req->new_response(200)->finalize;
+    };
+
+    test_psgi $app, sub {
+        my $cb = shift;
+
+        my $req = POST "/";
+        my $encocded_json = encode_json($data);
+        $req->header('Content-Type' => 'application/json; charset=utf-8');
+        $req->header('Content-Length' => length $encocded_json);
+        $req->content($encocded_json);
+
+        $cb->($req);
+    };
+}
+
+run_test({ b => ['hello'] });
+run_test({ b => [] });
+
+done_testing;


### PR DESCRIPTION
This pull request solves the following problems.  

## Problem

When requesting JSON with one or zero array elements, the body parameters are no longer an array:

```
Case: POST { b => [123] }
Then: { b => 123} 
Expected body parameters : { b => [123] }

Case: POST { b => [] }
Then: {} 
Expected body parameters : { b => [] }
```

The following test code reproduces this problem. t/100_bugs/002_a_few_parameters_in_json_body.t

## Solutions

1. Decode body parameters recursively.
2. Added `json_parameters` method for easier handling of JSON requests.

