### PR TITLE
added missing documentation for halt_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ per-request object, herds request and response
 
     die and response immediately
 
+- halt\_text(status\_code, message)
+
+    die and response immediately
+
+    set Content-Type to text/plain
+
+- halt\_no\_content(status\_code)
+
+    die and response immediately
+
+    set Content-Length to 0
+
 - redirect($uri,status\_code): Kossy::Response
 - render($file,$args): Kossy::Response
 

--- a/lib/Kossy.pm
+++ b/lib/Kossy.pm
@@ -431,6 +431,18 @@ path parameters captured by Router::Boom
 
 die and response immediately
 
+=item halt_text(status_code, message)
+
+die and response immediately
+
+set Content-Type to text/plain
+
+=item halt_no_content(status_code)
+
+die and response immediately
+
+set Content-Length to 0
+
 =item redirect($uri,status_code): Kossy::Response
 
 =item render($file,$args): Kossy::Response


### PR DESCRIPTION
In this PR (<https://github.com/kazeburo/Kossy/pull/15>), added  halt_* methods.
But, there are nothing documentation.